### PR TITLE
Fixed compile in latest Idris (0.12.3)

### DIFF
--- a/src/Derive/DecEq.idr
+++ b/src/Derive/DecEq.idr
@@ -37,17 +37,17 @@ declareDecEq fn (MkDatatype tyn tyconArgs tyconRes cons) =
 makeClause : TTName -> ((TTName, Raw), (TTName, Raw)) -> Elab (Maybe FunClause)
 makeClause fn ((cn1, ct1), (cn2, ct2)) =
   if cn1 == cn2
-    then return Nothing
+    then pure Nothing
     else
       do (args1, res1) <- stealBindings ct1 (const Nothing)
          (args2, res2) <- stealBindings ct2 (const Nothing)
          let rhsGoal = bindPatTys (args1 ++ args2) $ RType --no
-         return Nothing
+         pure Nothing
 
 makeDecEqClauses : TTName -> List ((TTName, Raw), (TTName, Raw)) -> Elab (List FunClause)
 makeDecEqClauses fn cases =
   do res <- traverse (makeClause fn) cases
-     return $ justs res
+     pure $ justs res
   where justs : List (Maybe a) -> List a
         justs [] = []
         justs (Nothing::xs) = justs xs

--- a/src/Derive/Eq.idr
+++ b/src/Derive/Eq.idr
@@ -117,7 +117,7 @@ ctorClause fam eq info ctor =
                             checkArg
 
                             focus todo
-                            [next] <- apply `(Delay {t=LazyEval} {a=Bool}) [False]
+                            [next] <- apply `(Delay {t=LazyValue} {a=Bool}) [False]
                             solve
                             focus next
                             checkEq args
@@ -173,7 +173,7 @@ instClause : (eq, instn : TTName) ->
              (instArgs, instConstrs : List FunArg) ->
              Elab (List (FunClause Raw))
 instClause eq instn info instArgs instConstrs =
-  do let baseCtorN = SN (InstanceCtorN `{Interfaces.Eq})
+  do let baseCtorN = SN (ImplementationCtorN `{Interfaces.Eq})
      (ctorN, _, _) <- lookupTyExact baseCtorN
      clause <- elabPatternClause
                  (do apply (Var instn)
@@ -229,7 +229,8 @@ deriveEq fam =
      info <- getTyConInfo (tyConArgs datatype) (tyConRes datatype)
      decl <- declareEq fam eq info
      declareType decl
-     let instn = NS (SN $ InstanceN `{Interfaces.Eq} [show fam]) !currentNamespace
+     let instn = NS (SN $ ImplementationN `{Interfaces.Eq} [show fam])
+                    !currentNamespace
      instConstrs <- Foldable.concat <$>
                     traverse (\ param =>
                                 case param of
@@ -250,7 +251,7 @@ deriveEq fam =
      defineFunction $ DefineFun eq (clauses ++ [!(catchall eq info)])
      defineFunction $
        DefineFun instn !(instClause eq instn info instArgs instConstrs)
-     addInstance `{Interfaces.Eq} instn
+     addImplementation `{Interfaces.Eq} instn
      pure ()
 
   where tcArgName : TyConArg -> TTName

--- a/src/Derive/Show.idr
+++ b/src/Derive/Show.idr
@@ -184,7 +184,7 @@ instClause : (sh, instn : TTName) ->
              (instArgs, instConstrs : List FunArg) ->
              Elab (List (FunClause Raw))
 instClause sh instn info instArgs instConstrs =
-  do let baseCtorN = SN (InstanceCtorN `{Show})
+  do let baseCtorN = SN (ImplementationCtorN `{Show})
      (ctorN, _, _) <- lookupTyExact baseCtorN
      clause <- elabPatternClause
                  (do apply (Var instn)
@@ -241,7 +241,7 @@ deriveShow fam =
        info <- getTyConInfo (tyConArgs datatype) (tyConRes datatype)
        decl <- declareShow fam sh info
        declareType decl
-       let instn = NS (SN $ InstanceN `{Show} [show fam]) !currentNamespace
+       let instn = NS (SN $ ImplementationN `{Show} [show fam]) !currentNamespace
        instConstrs <- Foldable.concat <$>
                       traverse (\ param =>
                                   case param of
@@ -261,7 +261,7 @@ deriveShow fam =
        defineFunction $ DefineFun sh clauses
        defineFunction $
          DefineFun instn !(instClause sh instn info instArgs instConstrs)
-       addInstance `{Show} instn
+       addImplementation `{Show} instn
        pure ()
   where tcArgName : TyConArg -> TTName
         tcArgName (TyConParameter x) = name x

--- a/src/Derive/Util/TyConInfo.idr
+++ b/src/Derive/Util/TyConInfo.idr
@@ -48,14 +48,14 @@ alphaTyConInfo ren (MkTyConInfo (tcArg::tcArgs) res) =
   in MkTyConInfo (tcArg'::tcArgs') res'
 
 getTyConInfo' : List TyConArg -> Raw -> (TTName -> Maybe TTName) -> Elab TyConInfo
-getTyConInfo' [] res _ = return (MkTyConInfo [] res)
+getTyConInfo' [] res _ = pure (MkTyConInfo [] res)
 getTyConInfo' (tcArg::tcArgs) res ren =
   do let n = tyConArgName tcArg
      n' <- nameFrom n
      let ren' = extend ren n n'
      -- n' is globally unique so we don't worry about scope
      next <- getTyConInfo' tcArgs (RApp res (Var n')) ren'
-     return $ alphaTyConInfo ren' $
+     pure $ alphaTyConInfo ren' $
        record {args = setTyConArgName tcArg n' :: args next} next
 
 getTyConInfo : List TyConArg -> Raw -> Elab TyConInfo
@@ -65,14 +65,14 @@ getTyConInfo args res = getTyConInfo' args res (const Nothing)
 processCtorArgs : TyConInfo -> (TTName, List CtorArg, Raw) -> Elab (TTName, List CtorArg, Raw)
 processCtorArgs info (cn, cargs, resTy) =
     do (args', ty') <- convert' (const Nothing) cargs resTy info
-       return (cn, args', ty')
+       pure (cn, args', ty')
   where
     ||| Find the name that was assigned to a given parameter
     ||| by comparing positions in the TyConInfo
     findParam : TTName -> List Raw -> List TyConArg -> Elab TTName
     findParam paramN (Var n :: args) (TyConParameter a :: tcArgs) =
       if n == paramN
-        then return (argName a)
+        then pure (argName a)
         else findParam paramN args tcArgs
     findParam paramN (_ :: args) (_ :: tcArgs) =
       findParam paramN args tcArgs
@@ -84,7 +84,7 @@ processCtorArgs info (cn, cargs, resTy) =
     convert' : (TTName -> Maybe TTName) ->
                List CtorArg -> Raw ->
                TyConInfo -> Elab (List CtorArg, Raw)
-    convert' subst [] ty info = return ([], alphaRaw subst ty)
+    convert' subst [] ty info = pure ([], alphaRaw subst ty)
     convert' subst (CtorField a :: args) ty info =
       do n' <- nameFrom (argName a)
          let a' = record {
@@ -93,7 +93,7 @@ processCtorArgs info (cn, cargs, resTy) =
                   } a
          let subst' = extend subst (argName a) n'
          (args', ty') <- convert' subst' args ty info
-         return (CtorField a' :: args', ty')
+         pure (CtorField a' :: args', ty')
     convert' subst (CtorParameter a :: ctorArgs) ty info =
       do n' <- findParam (argName a) (snd (unApply ty)) (args info)
          let a' = record {
@@ -102,4 +102,4 @@ processCtorArgs info (cn, cargs, resTy) =
                   } a
          let subst' = extend subst (argName a) n'
          (args', ty') <- convert' subst' ctorArgs ty info
-         return (CtorParameter a' :: args', ty')
+         pure (CtorParameter a' :: args', ty')


### PR DESCRIPTION
`LazyEval` has been renamed to `LazyValue`, preventing this project from compiling.

I fixed this, and also took the liberty of fixing all uses of deprecated names; specifically: `return`, `InstanceN`, `InstanceCtorN`, and `addInstance`.
