### PR TITLE
Removed match on NErased:TTName in Show.idr

### DIFF
--- a/src/Derive/Show.idr
+++ b/src/Derive/Show.idr
@@ -55,7 +55,6 @@ strName (UN n) = case unpack n of
 strName (NS n _) = strName n
 strName (MN x y) = y
 strName (SN x) = "**SN**" -- won't happen with user-declared types
-strName NErased = "**Erased**" -- won't happen with user-declared types
 
 ||| Make the show clause for a single constructor
 ctorClause : (fam, sh : TTName) -> (info : TyConInfo) ->


### PR DESCRIPTION
NErased is no longer a constructor of TTName, and matching on it is an error in 1.2.0:ab9a0fd4. 1.2.0 release version accepts but doesn't require it, even in functions declared total, likely ignoring it silently.