### PR TITLE
Fix for Idris 1.3

### DIFF
--- a/src/Derive/Kit.idr
+++ b/src/Derive/Kit.idr
@@ -22,7 +22,7 @@ last [x] = pure x
 last (_::x::xs) = last (x::xs)
 
 getSigmaArgs : Raw -> Elab (Raw, Raw)
-getSigmaArgs `(MkSigma {a=~_} {P=~_} ~rhsTy ~lhs) = pure (rhsTy, lhs)
+getSigmaArgs `(MkDPair {a=~_} {P=~_} ~rhsTy ~lhs) = pure (rhsTy, lhs)
 getSigmaArgs arg = fail [TextPart "Not a sigma constructor"]
 
 

--- a/src/Derive/Show.idr
+++ b/src/Derive/Show.idr
@@ -55,7 +55,7 @@ strName (UN n) = case unpack n of
 strName (NS n _) = strName n
 strName (MN x y) = y
 strName (SN x) = "**SN**" -- won't happen with user-declared types
-strName NErased = "**Erased**" -- won't happen with user-declared types
+strName nErased = "**Erased**" -- won't happen with user-declared types
 
 ||| Make the show clause for a single constructor
 ctorClause : (fam, sh : TTName) -> (info : TyConInfo) ->


### PR DESCRIPTION
- Upper case identifiers aren't valid anymore
- MkSigma has been deprecated in favor of MkDPair